### PR TITLE
Added docker to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Or in Docker. Content of a Dockerfile
 ```
 FROM node:latest
 RUN npm install -g @mspnp/azure-building-blocks
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release) main" > \
+    /etc/apt/sources.list.d/azure-cli.list && \
+    apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893 && \
+    apt-get update && \
+    apt-get install azure-cli && \
+    az
 ```
 Build container
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ Verify the version of azure building blocks you are running using the command be
 azbb -V
 ```
 
+Or in Docker. Content of a Dockerfile
+
+```
+FROM node:latest
+RUN npm install -g @mspnp/azure-building-blocks
+```
+Build container
+
+```
+docker build -t azure-building-blocks:<version> .
+```
+
+Run container
+
+```
+docker run -it --name azbb-<version> -v <path to folder containing json files>:/data azure-building-blocks:<version> bash
+```
+
 Then, [author an Azure Building Blocks parameter file](https://github.com/mspnp/template-building-blocks/wiki/create-a-template-building-blocks-parameter-file) and [run the `azbb` command line tool](https://github.com/mspnp/template-building-blocks/wiki/command-line-reference).
 
 # Documentation


### PR DESCRIPTION
Docker can be useful if you do not want to install azbb directly on your system. And you can have azbb in different versions.