### PR TITLE
Increased the maxBuffer for spawnAz. Fixes: #418

### DIFF
--- a/src/azCLI.js
+++ b/src/azCLI.js
@@ -11,7 +11,8 @@ let spawnAz = ({args, spawnOptions, azOptions}) => {
 
     spawnOptions = spawnOptions || {
         stdio: 'pipe',
-        shell: true
+        shell: true,
+        maxBuffer: 1024 * 1024 * 100
     };
 
     azOptions = azOptions || {


### PR DESCRIPTION
Increased the maxBuffer for the childProcess from default (200 * 1024 (20B)) to 1024 * 1024 * 100 (100MB)