### PR TITLE
Increasing child_process buffer size to fix issue #418

### DIFF
--- a/src/azCLI.js
+++ b/src/azCLI.js
@@ -11,7 +11,8 @@ let spawnAz = ({args, spawnOptions, azOptions}) => {
 
     spawnOptions = spawnOptions || {
         stdio: 'pipe',
-        shell: true
+        shell: true,
+        maxBuffer : 1024*1024*10
     };
 
     azOptions = azOptions || {


### PR DESCRIPTION
The az get-skus command returns too much data for the default child_process buffer size. Increasing the maxBuffer to 10x the default size.

https://github.com/nodejs/node/blob/master/doc/api/child_process.md